### PR TITLE
Added additional output processor for the SQLExecuteQueryOperator

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -121,7 +121,9 @@ def default_output_processor_with_column_names(
     results: list[Any], descriptions: list[Sequence[Sequence] | None]
 ) -> list[tuple[Any, list[str]]]:
     """
-    Returns both the data and column names when used as output_processor of the SQLExecuteQueryOperator.
+    Return both the data and column names of one or more queries executed with the SQLExecuteQueryOperator.
+
+    This method needs to be set as the value of the output_processor parameter.
 
     Args:
         results (list[Any]): The data outputs of the executed queries.

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -113,6 +113,32 @@ def resolve_dialects() -> MutableMapping[str, MutableMapping]:
     }
 
 
+def default_output_processor(results: list[Any], descriptions: list[Sequence[Sequence] | None]) -> list[Any]:
+    return results
+
+
+def default_output_processor_with_column_names(
+    results: list[Any], descriptions: list[Sequence[Sequence] | None]
+) -> list[tuple[Any, list[str]]]:
+    """
+    Returns both the data and column names when used as output_processor of the SQLExecuteQueryOperator.
+
+    Args:
+        results (list[Any]): The data outputs of the executed queries.
+        descriptions (list[Sequence[Sequence] | None]): The column descriptions of the executed queries (description attribute of the corresponding cursor).
+
+    Returns:
+        list[tuple[Any, list[str]]]: A list with an item for each SQL statement that was executed.
+        Each list item is a tuple of 1. the data and 2. the corresponding column names resulting from the SQL statement in question.
+    """
+    column_names = [
+        [single_col_desc[0] for single_col_desc in query_col_desc] if query_col_desc is not None else None
+        for query_col_desc in descriptions
+    ]
+    output = list(zip(results, column_names))
+    return output
+
+
 class ConnectorProtocol(Protocol):
     """Database connection protocol."""
 

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
@@ -26,7 +26,12 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, NoReturn, SupportsAbs
 from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, SkipMixin
-from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, return_single_query_results
+from airflow.providers.common.sql.hooks.sql import (
+    DbApiHook,
+    default_output_processor,
+    fetch_all_handler,
+    return_single_query_results,
+)
 from airflow.utils.helpers import merge_dicts
 
 if TYPE_CHECKING:
@@ -114,32 +119,6 @@ _MIN_SUPPORTED_PROVIDERS_VERSION = {
     "trino": "3.1.0",
     "vertica": "3.1.0",
 }
-
-
-def default_output_processor(results: list[Any], descriptions: list[Sequence[Sequence] | None]) -> list[Any]:
-    return results
-
-
-def output_processor_with_column_names(
-    results: list[Any], descriptions: list[Sequence[Sequence] | None]
-) -> list[tuple[Any, list[str]]]:
-    """
-    Returns both the data and column names when used as output_processor of the SQLExecuteQueryOperator.
-
-    Args:
-        results (list[Any]): The data outputs of the executed queries.
-        descriptions (list[Sequence[Sequence] | None]): The column descriptions of the executed queries (description attribute of the corresponding cursor).
-
-    Returns:
-        list[tuple[Any, list[str]]]: A list with an item for each SQL statement that was executed.
-        Each list item is a tuple of 1. the data and 2. the corresponding column names resulting from the SQL statement in question.
-    """
-    column_names = [
-        [single_col_desc[0] for single_col_desc in query_col_desc] if query_col_desc is not None else None
-        for query_col_desc in descriptions
-    ]
-    output = list(zip(results, column_names))
-    return output
 
 
 class BaseSQLOperator(BaseOperator):

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
@@ -120,6 +120,28 @@ def default_output_processor(results: list[Any], descriptions: list[Sequence[Seq
     return results
 
 
+def output_processor_with_column_names(
+    results: list[Any], descriptions: list[Sequence[Sequence] | None]
+) -> list[tuple[Any, list[str]]]:
+    """
+    Returns both the data and column names when used as output_processor of the SQLExecuteQueryOperator.
+
+    Args:
+        results (list[Any]): The data outputs of the executed queries.
+        descriptions (list[Sequence[Sequence] | None]): The column descriptions of the executed queries (description attribute of the corresponding cursor).
+
+    Returns:
+        list[tuple[Any, list[str]]]: A list with an item for each SQL statement that was executed.
+        Each list item is a tuple of 1. the data and 2. the corresponding column names resulting from the SQL statement in question.
+    """
+    column_names = [
+        [single_col_desc[0] for single_col_desc in query_col_desc] if query_col_desc is not None else None
+        for query_col_desc in descriptions
+    ]
+    output = list(zip(results, column_names))
+    return output
+
+
 class BaseSQLOperator(BaseOperator):
     """
     This is a base class for generic SQL Operator to get a DB Hook.


### PR DESCRIPTION
* Added an additional output processor for the `SQLExecuteQueryOperator` which returns both the data and the column names of the query result(s).
* The original output processor (`default_output_processor`) remains unchanged but is moved from the `operators` to the `hooks` folder.

related: #44781

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
